### PR TITLE
Add null safety check for missing request path

### DIFF
--- a/router/src/main/kotlin/io/moia/router/RequestPredicate.kt
+++ b/router/src/main/kotlin/io/moia/router/RequestPredicate.kt
@@ -38,9 +38,8 @@ data class RequestPredicate(
             matchContentType = contentTypeMatches(request.contentType(), consumes)
         )
 
-    private fun pathMatches(request: APIGatewayProxyRequestEvent) = UriTemplate.from(
-        pathPattern
-    ).matches(request.path)
+    private fun pathMatches(request: APIGatewayProxyRequestEvent) =
+        request.path?.let { UriTemplate.from(pathPattern).matches(it) } ?: false
     private fun methodMatches(request: APIGatewayProxyRequestEvent) = method.equals(request.httpMethod, true)
     private fun contentTypeMatches(contentType: String?, accepted: Set<String>) =
         if (accepted.isEmpty() && contentType == null) true

--- a/router/src/test/kotlin/io/moia/router/RequestHandlerTest.kt
+++ b/router/src/test/kotlin/io/moia/router/RequestHandlerTest.kt
@@ -244,6 +244,24 @@ class RequestHandlerTest {
         assert(response.statusCode).isEqualTo(401)
     }
 
+    @Test
+    fun `Request without headers should return status code 406`() {
+        val response = testRequestHandler.handleRequest(
+            GET("/some"),
+            mockk()
+        )
+        assert(response.statusCode).isEqualTo(406)
+    }
+
+    @Test
+    fun `Request without request path should return status code 404`() {
+        val response = testRequestHandler.handleRequest(
+            GET(),
+            mockk()
+        )
+        assert(response.statusCode).isEqualTo(404)
+    }
+
     class TestRequestHandlerAuthorization : RequestHandler() {
         override val router = router {
             GET("/some") { _: Request<Unit> ->


### PR DESCRIPTION
Background: The serverless warmup lambda plugin invokes the lambda without any headers or a request path present. This should not throw exceptions.