### PR TITLE
Go back to guava MediaType

### DIFF
--- a/gradle/wrapper/gradle-wrapper.properties
+++ b/gradle/wrapper/gradle-wrapper.properties
@@ -1,5 +1,5 @@
 distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-5.3-bin.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-5.4-bin.zip
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists

--- a/router-protobuf/src/main/kotlin/io/moia/router/proto/ProtoSerializationHandler.kt
+++ b/router-protobuf/src/main/kotlin/io/moia/router/proto/ProtoSerializationHandler.kt
@@ -1,21 +1,21 @@
 package io.moia.router.proto
 
+import com.google.common.net.MediaType
 import com.google.protobuf.GeneratedMessageV3
 import io.moia.router.ResponseEntity
 import io.moia.router.SerializationHandler
-import org.apache.http.entity.ContentType
 import java.util.Base64
 
 class ProtoSerializationHandler : SerializationHandler {
 
-    private val json = ContentType.parse("application/json")
+    private val json = MediaType.parse("application/json")
 
-    override fun supports(acceptHeader: ContentType, response: ResponseEntity<*>): Boolean =
+    override fun supports(acceptHeader: MediaType, response: ResponseEntity<*>): Boolean =
         response.body is GeneratedMessageV3
 
-    override fun serialize(acceptHeader: ContentType, response: ResponseEntity<*>): String {
+    override fun serialize(acceptHeader: MediaType, response: ResponseEntity<*>): String {
         val message = response.body as GeneratedMessageV3
-        return if (json.mimeType == acceptHeader.mimeType) {
+        return if (acceptHeader.`is`(json)) {
             ProtoBufUtils.toJsonWithoutWrappers(message)
         } else {
             Base64.getEncoder().encodeToString(message.toByteArray())

--- a/router/build.gradle.kts
+++ b/router/build.gradle.kts
@@ -9,7 +9,7 @@ dependencies {
     compile("org.slf4j:slf4j-api:1.7.26")
     compile("com.fasterxml.jackson.core:jackson-databind:2.9.8")
     compile("com.fasterxml.jackson.module:jackson-module-kotlin:2.9.8")
-    compile("org.apache.httpcomponents:httpcore:4.4.11")
+    compile("com.google.guava:guava:23.0")
 
     testImplementation("org.junit.jupiter:junit-jupiter-engine:5.4.0")
     testImplementation("org.junit.jupiter:junit-jupiter-params:5.4.0")

--- a/router/src/main/kotlin/io/moia/router/DeserializationHandler.kt
+++ b/router/src/main/kotlin/io/moia/router/DeserializationHandler.kt
@@ -3,7 +3,7 @@ package io.moia.router
 import com.amazonaws.services.lambda.runtime.events.APIGatewayProxyRequestEvent
 import com.fasterxml.jackson.databind.ObjectMapper
 import com.fasterxml.jackson.databind.type.TypeFactory
-import org.apache.http.entity.ContentType
+import com.google.common.net.MediaType
 import kotlin.reflect.KClass
 import kotlin.reflect.KType
 import kotlin.reflect.full.isSubclassOf
@@ -27,10 +27,10 @@ class DeserializationHandlerChain(private val handlers: List<DeserializationHand
 
 class JsonDeserializationHandler(private val objectMapper: ObjectMapper) : DeserializationHandler {
 
-    private val json = ContentType.parse("application/json")
+    private val json = MediaType.parse("application/json")
 
     override fun supports(input: APIGatewayProxyRequestEvent) =
-            input.contentType() != null && ContentType.parse(input.contentType()).mimeType == json.mimeType
+        input.contentType() != null && MediaType.parse(input.contentType()!!).`is`(json)
 
     override fun deserialize(input: APIGatewayProxyRequestEvent, target: KType?): Any? {
         val targetClass = target?.classifier as KClass<*>

--- a/router/src/main/kotlin/io/moia/router/SerializationHandler.kt
+++ b/router/src/main/kotlin/io/moia/router/SerializationHandler.kt
@@ -1,31 +1,31 @@
 package io.moia.router
 
 import com.fasterxml.jackson.databind.ObjectMapper
-import org.apache.http.entity.ContentType
+import com.google.common.net.MediaType
 
 interface SerializationHandler {
 
-    fun supports(acceptHeader: ContentType, response: ResponseEntity<*>): Boolean
+    fun supports(acceptHeader: MediaType, response: ResponseEntity<*>): Boolean
 
-    fun serialize(acceptHeader: ContentType, response: ResponseEntity<*>): String
+    fun serialize(acceptHeader: MediaType, response: ResponseEntity<*>): String
 }
 
 class SerializationHandlerChain(private val handlers: List<SerializationHandler>) :
     SerializationHandler {
 
-    override fun supports(acceptHeader: ContentType, response: ResponseEntity<*>): Boolean =
+    override fun supports(acceptHeader: MediaType, response: ResponseEntity<*>): Boolean =
         handlers.any { it.supports(acceptHeader, response) }
 
-    override fun serialize(acceptHeader: ContentType, response: ResponseEntity<*>): String =
+    override fun serialize(acceptHeader: MediaType, response: ResponseEntity<*>): String =
         handlers.first { it.supports(acceptHeader, response) }.serialize(acceptHeader, response)
 }
 
 class JsonSerializationHandler(private val objectMapper: ObjectMapper) : SerializationHandler {
 
-    private val json = ContentType.parse("application/json")
+    private val json = MediaType.parse("application/json")
 
-    override fun supports(acceptHeader: ContentType, response: ResponseEntity<*>): Boolean = acceptHeader.mimeType == json.mimeType
+    override fun supports(acceptHeader: MediaType, response: ResponseEntity<*>): Boolean = acceptHeader.`is`(json)
 
-    override fun serialize(acceptHeader: ContentType, response: ResponseEntity<*>): String =
+    override fun serialize(acceptHeader: MediaType, response: ResponseEntity<*>): String =
         objectMapper.writeValueAsString(response.body)
 }

--- a/router/src/test/kotlin/io/moia/router/RequestHandlerTest.kt
+++ b/router/src/test/kotlin/io/moia/router/RequestHandlerTest.kt
@@ -193,13 +193,15 @@ class RequestHandlerTest {
         val response = testRequestHandler.handleRequest(
             POST("/some")
                 .withHeaders(mapOf(
-                    "Accept" to "application/json, application/xhtml+xml, application/xml;q=0.9, image/webp, */*;q=0.8",
+                    "Accept" to "application/xhtml+xml, application/json, application/xml;q=0.9, image/webp, */*;q=0.8",
                     "Content-Type" to "application/json"
                 ))
                 .withBody("""{ "greeting": "some" }"""), mockk()
         )
 
         assert(response.statusCode).isEqualTo(200)
+        assert(response.getHeaderCaseInsensitive("content-type")).isEqualTo("application/json")
+
         assert(response.body).isEqualTo("""{"greeting":"some"}""")
     }
 


### PR DESCRIPTION
This is done because it can handle wildcards.
Apache http ContentType did not correctly handle multiple media types (it just chose the first one) and
it could not handle wildcards.

Multiple media types in an accept header are now handled by splitting the header value.

Also we do no longer use the accept header as the content type of the request (accept header can state multiple media types). But we use the matched media type from the ones the handler can produce.