### PR TITLE
Make path parameters mandatory

### DIFF
--- a/router/src/main/kotlin/io/moia/router/Router.kt
+++ b/router/src/main/kotlin/io/moia/router/Router.kt
@@ -78,7 +78,7 @@ data class Request<I>(val apiRequest: APIGatewayProxyRequestEvent, val body: I, 
     val pathParameters by lazy { UriTemplate.from(pathPattern).extract(apiRequest.path) }
     val queryParameters: Map<String, String>? by lazy { apiRequest.queryStringParameters }
     val multiValueQueryStringParameters: Map<String, List<String>>? by lazy { apiRequest.multiValueQueryStringParameters }
-    fun getPathParameter(name: String): String? = pathParameters[name]
+    fun getPathParameter(name: String): String = pathParameters[name] ?: error("Could not find path parameter '$name")
     fun getQueryParameter(name: String): String? = queryParameters?.get(name)
     fun getMultiValueQueryStringParameter(name: String): List<String>? = multiValueQueryStringParameters?.get(name)
 }

--- a/router/src/test/kotlin/io/moia/router/RequestHandlerTest.kt
+++ b/router/src/test/kotlin/io/moia/router/RequestHandlerTest.kt
@@ -9,6 +9,7 @@ import assertk.assertions.isTrue
 import com.amazonaws.services.lambda.runtime.events.APIGatewayProxyRequestEvent
 import io.mockk.mockk
 import io.moia.router.Router.Companion.router
+import org.junit.jupiter.api.Assertions.assertEquals
 import org.junit.jupiter.api.Test
 
 class RequestHandlerTest {
@@ -371,6 +372,17 @@ class RequestHandlerTest {
         )
     }
 
+    @Test
+    fun `Not existing path parameter should throw an error`() {
+        val response = testRequestHandler.handleRequest(
+            GET("/non-existing-path-parameter")
+                .withHeader("accept", "application/json"),
+            mockk()
+        )
+        assertEquals(500, response.statusCode)
+        assertEquals("{\"message\":\"Could not find path parameter 'foo\",\"code\":\"INTERNAL_SERVER_ERROR\",\"details\":{}}", response.body)
+    }
+
     class TestRequestHandlerAuthorization : RequestHandler() {
         override val router = router {
             GET("/some") { _: Request<Unit> ->
@@ -474,6 +486,10 @@ class RequestHandlerTest {
             }
             DELETE("/delete-me") { _: Request<Unit> ->
                 ResponseEntity.noContent()
+            }
+            GET("/non-existing-path-parameter") { request: Request<Unit> ->
+                request.getPathParameter("foo")
+                ResponseEntity.ok(null)
             }
         }
     }


### PR DESCRIPTION
Background: AWS API Gateway does not allow optional path parameters. Making them not-nullable saves a lot of tests (because you don't have to test both cases any more in all your handlers).