### PR TITLE
Handle null bodies better

### DIFF
--- a/router/src/main/kotlin/io/moia/router/RequestHandler.kt
+++ b/router/src/main/kotlin/io/moia/router/RequestHandler.kt
@@ -94,6 +94,8 @@ abstract class RequestHandler : RequestHandler<APIGatewayProxyRequestEvent, APIG
         val requestType = handler.reflect()!!.parameters.first().type.arguments.first().type
         return when {
             requestType?.classifier as KClass<*> == Unit::class -> Unit
+            input.body == null && requestType.isMarkedNullable -> null
+            input.body == null -> throw ApiException("no request body present", "REQUEST_BODY_MISSING", 400)
             else -> deserializationHandlerChain.deserialize(input, requestType)
         }
     }

--- a/router/src/test/kotlin/io/moia/router/RequestHandlerTest.kt
+++ b/router/src/test/kotlin/io/moia/router/RequestHandlerTest.kt
@@ -275,6 +275,40 @@ class RequestHandlerTest {
     }
 
     @Test
+    fun `should return 400 on missing body when content type stated`() {
+
+        val response = testRequestHandler.handleRequest(
+            POST("/some")
+                .withHeaders(
+                    mapOf(
+                        "Accept" to "application/json",
+                        "Content-Type" to "application/json"
+                    )
+                )
+                .withBody(null), mockk()
+        )
+        assert(response.statusCode).isEqualTo(400)
+        assert(mapper.readValue<ApiError>(response.body).code).isEqualTo("REQUEST_BODY_MISSING")
+    }
+
+    @Test
+    fun `should handle null body when content type is stated and request handler body type is nullable`() {
+
+        val response = testRequestHandler.handleRequest(
+            POST("/some-nullable")
+                .withHeaders(
+                    mapOf(
+                        "Accept" to "application/json",
+                        "Content-Type" to "application/json"
+                    )
+                )
+                .withBody(null), mockk()
+        )
+        assert(response.statusCode).isEqualTo(200)
+        assert(response.body).isEqualTo("""{"greeting":""}""")
+    }
+
+    @Test
     fun `should handle api exception`() {
 
         val response = testRequestHandler.handleRequest(
@@ -526,7 +560,7 @@ class RequestHandlerTest {
     }
 
     @Test
-    fun `Handler should return the content type that is accepted`() {
+    fun `should return the content type that is accepted`() {
         val jsonResponse = AcceptTypeDependingHandler().handleRequest(
             GET("/all-objects")
                 .withHeader("accept", "application/json"),
@@ -648,7 +682,7 @@ class RequestHandlerTest {
                 )
             }
 
-            POST("/some") { r: Request<TestRequest> ->
+            POST("/some") { _: Request<TestRequest> ->
                 ResponseEntity.ok(
                     TestResponse(
                         "v2"
@@ -663,6 +697,14 @@ class RequestHandlerTest {
                     )
                 )
             }.producing("application/json", "application/*+json")
+
+            POST("/some-nullable") { r: Request<TestRequest?> ->
+                ResponseEntity.ok(
+                    TestResponse(
+                        r.body?.greeting.orEmpty()
+                    )
+                )
+            }.producing("application/json")
 
             POST("/somes") { r: Request<List<TestRequest>> ->
                 ResponseEntity.ok(r.body.map {


### PR DESCRIPTION
If request handler request type is `nullable` pass `null` otherwise fail with `400`.

closes #33 

Invalid JSON was already handled see https://github.com/moia-dev/lambda-kotlin-request-router/blob/12d98b5afb225128182863aa25d079c8c4b4e26c/router/src/test/kotlin/io/moia/router/RequestHandlerTest.kt#L254