### PR TITLE
Allow parameters in content type header

### DIFF
--- a/router/src/main/kotlin/io/moia/router/DeserializationHandler.kt
+++ b/router/src/main/kotlin/io/moia/router/DeserializationHandler.kt
@@ -51,7 +51,8 @@ class JsonDeserializationHandler(private val objectMapper: ObjectMapper) : Deser
         if (input.contentType() == null)
             false
         else {
-            MediaType.parse(input.contentType()!!).let { json.isCompatibleWith(it) || jsonStructuredSuffixWildcard.isCompatibleWith(it) }
+            MediaType.parse(input.contentType()!!).withoutParameters()
+                .let { json.isCompatibleWith(it) || jsonStructuredSuffixWildcard.isCompatibleWith(it) }
         }
 
     override fun deserialize(input: APIGatewayProxyRequestEvent, target: KType?): Any? {

--- a/router/src/main/kotlin/io/moia/router/DeserializationHandler.kt
+++ b/router/src/main/kotlin/io/moia/router/DeserializationHandler.kt
@@ -44,14 +44,14 @@ class DeserializationHandlerChain(private val handlers: List<DeserializationHand
 
 class JsonDeserializationHandler(private val objectMapper: ObjectMapper) : DeserializationHandler {
 
-    private val json = MediaType.parse("application/json")
-    private val jsonStructuredSuffixWildcard = MediaType.parse("application/*+json")
+    private val json = MediaType.parse("application/json; charset=UTF-8")
+    private val jsonStructuredSuffixWildcard = MediaType.parse("application/*+json; charset=UTF-8")
 
     override fun supports(input: APIGatewayProxyRequestEvent) =
         if (input.contentType() == null)
             false
         else {
-            MediaType.parse(input.contentType()!!).withoutParameters()
+            MediaType.parse(input.contentType()!!)
                 .let { json.isCompatibleWith(it) || jsonStructuredSuffixWildcard.isCompatibleWith(it) }
         }
 

--- a/router/src/main/kotlin/io/moia/router/MediaTypeExtensions.kt
+++ b/router/src/main/kotlin/io/moia/router/MediaTypeExtensions.kt
@@ -20,8 +20,7 @@ fun MediaType.isCompatibleWith(other: MediaType): Boolean =
     if (this.`is`(other))
         true
     else {
-        type() == other.type() &&
-            (subtype().contains("+") && other.subtype().contains("+")) &&
-            this.subtype().substringBeforeLast("+") == "*" &&
-            this.subtype().substringAfterLast("+") == other.subtype().substringAfterLast("+")
+        type() == other.type() && (subtype().contains("+") && other.subtype().contains("+")) && this.subtype()
+            .substringBeforeLast("+") == "*" && this.subtype().substringAfterLast("+") == other.subtype()
+            .substringAfterLast("+") && (other.parameters().isEmpty || this.parameters() == other.parameters())
     }

--- a/router/src/test/kotlin/io/moia/router/JsonDeserializationHandlerTest.kt
+++ b/router/src/test/kotlin/io/moia/router/JsonDeserializationHandlerTest.kt
@@ -59,7 +59,7 @@ class JsonDeserializationHandlerTest {
     }
 
     @Test
-    fun `should support json with charset parameter`() {
+    fun `should support json with UTF-8 charset parameter`() {
         assertTrue(
             deserializationHandler.supports(
                 APIGatewayProxyRequestEvent()
@@ -70,6 +70,22 @@ class JsonDeserializationHandlerTest {
             deserializationHandler.supports(
                 APIGatewayProxyRequestEvent()
                     .withHeader("content-type", "application/vnd.moia.v1+json; charset=UTF-8")
+            )
+        )
+    }
+
+    @Test
+    fun `should not support json with other charset parameter`() {
+        assertFalse(
+            deserializationHandler.supports(
+                APIGatewayProxyRequestEvent()
+                    .withHeader("content-type", "application/json; charset=UTF-16")
+            )
+        )
+        assertFalse(
+            deserializationHandler.supports(
+                APIGatewayProxyRequestEvent()
+                    .withHeader("content-type", "application/vnd.moia.v1+json; charset=UTF-16")
             )
         )
     }

--- a/router/src/test/kotlin/io/moia/router/JsonDeserializationHandlerTest.kt
+++ b/router/src/test/kotlin/io/moia/router/JsonDeserializationHandlerTest.kt
@@ -57,4 +57,20 @@ class JsonDeserializationHandlerTest {
             )
         )
     }
+
+    @Test
+    fun `should support json with charset parameter`() {
+        assertTrue(
+            deserializationHandler.supports(
+                APIGatewayProxyRequestEvent()
+                    .withHeader("content-type", "application/json; charset=UTF-8")
+            )
+        )
+        assertTrue(
+            deserializationHandler.supports(
+                APIGatewayProxyRequestEvent()
+                    .withHeader("content-type", "application/vnd.moia.v1+json; charset=UTF-8")
+            )
+        )
+    }
 }


### PR DESCRIPTION
For the partner API we sometimes get the charset parameter in the content type header (`application/json; charset=UTF-8`). This change allows the JSON deserialisation of such requests.