### PR TITLE
Add dependabot config

### DIFF
--- a/.dependabot/config.yml
+++ b/.dependabot/config.yml
@@ -1,0 +1,26 @@
+version: 1
+update_configs:
+  - package_manager: "java:gradle"
+    directory: "/"
+    update_schedule: "monthly"
+    automerged_updates:
+      - match:
+          update_type: "all"
+  - package_manager: "java:gradle"
+    directory: "/router/"
+    update_schedule: "monthly"
+    automerged_updates:
+      - match:
+          update_type: "all"
+  - package_manager: "java:gradle"
+    directory: "/router-protobuf/"
+    update_schedule: "monthly"
+    automerged_updates:
+      - match:
+          update_type: "all"
+  - package_manager: "java:gradle"
+    directory: "/router-openapi-request-validator/"
+    update_schedule: "monthly"
+    automerged_updates:
+      - match:
+          update_type: "all"


### PR DESCRIPTION
Dependabot is [now supporting Gradle files with Kotlin](https://github.com/dependabot/dependabot-core/blob/main/CHANGELOG.md#v01280-14-december-2020).