### PR TITLE
Remove subprojects from dependabot config to avoid duplicate PRs

### DIFF
--- a/.dependabot/config.yml
+++ b/.dependabot/config.yml
@@ -6,21 +6,3 @@ update_configs:
     automerged_updates:
       - match:
           update_type: "all"
-  - package_manager: "java:gradle"
-    directory: "/router/"
-    update_schedule: "monthly"
-    automerged_updates:
-      - match:
-          update_type: "all"
-  - package_manager: "java:gradle"
-    directory: "/router-protobuf/"
-    update_schedule: "monthly"
-    automerged_updates:
-      - match:
-          update_type: "all"
-  - package_manager: "java:gradle"
-    directory: "/router-openapi-request-validator/"
-    update_schedule: "monthly"
-    automerged_updates:
-      - match:
-          update_type: "all"


### PR DESCRIPTION
![](http://paulliotta.com/wp-content/uploads/2017/12/635950569960687999-788132076_gob-bluth.jpg)